### PR TITLE
applets are obsolete

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title> my java codes </title>
+	</head>
+	<body>
+		<p> Applets are obsolete </p>
+	</body>
+
+</html>


### PR DESCRIPTION
It's important to note that the use of Java applets has been deprecated and is no longer supported in modern web browsers. Applets were commonly used in the past for embedding Java programs in web pages,